### PR TITLE
Fix skipping in t/alien_base_modulebuild_pkgconfig.t

### DIFF
--- a/t/alien_base_modulebuild_pkgconfig.t
+++ b/t/alien_base_modulebuild_pkgconfig.t
@@ -77,46 +77,48 @@ subtest 'version' => sub {
 
   skip_all $skip if $skip;
 
-  my @installed = map { /^(\S+)/ ? $1 : () } `$pkg_config --list-all`;
-  skip "pkg-config returned no packages", 2 unless @installed;
-  my $lib = $installed[0];
+  SKIP: {
+      my @installed = map { /^(\S+)/ ? $1 : () } `$pkg_config --list-all`;
+      skip "pkg-config returned no packages", 2 unless @installed;
+      my $lib = $installed[0];
 
-  my ($builder_ok, $builder_bad) = map { 
-    require Alien::Base::ModuleBuild;
-    my($out, $builder) = capture_merged {
-      Alien::Base::ModuleBuild->new( 
-        module_name => 'My::Test', 
-        dist_version => 0.01,
-        alien_name => $_,
-        share_dir => 't',
-      );
-    };
-    note $out if $out ne '';
-    $builder;
+      my ($builder_ok, $builder_bad) = map { 
+        require Alien::Base::ModuleBuild;
+        my($out, $builder) = capture_merged {
+          Alien::Base::ModuleBuild->new( 
+            module_name => 'My::Test', 
+            dist_version => 0.01,
+            alien_name => $_,
+            share_dir => 't',
+          );
+        };
+        note $out if $out ne '';
+        $builder;
+      }
+      ($lib, 'siughspidghsp');
+
+      subtest 'good' => sub {
+      
+        my($out, $value) = capture_merged {
+          $builder_ok->alien_check_installed_version,
+        };
+        note $out if $out ne '';
+        
+        is( $value, T(), 'found installed library' );
+        note "lib is $lib";
+      
+      };
+      
+      subtest 'bad' => sub {
+        my($out, $value) = capture_merged {
+          $builder_bad->alien_check_installed_version,
+        };
+        note $out if $out ne '';
+        
+        is( $value, F(), "returns false if not found");
+        
+      };
   }
-  ($lib, 'siughspidghsp');
-
-  subtest 'good' => sub {
-  
-    my($out, $value) = capture_merged {
-      $builder_ok->alien_check_installed_version,
-    };
-    note $out if $out ne '';
-    
-    is( $value, T(), 'found installed library' );
-    note "lib is $lib";
-  
-  };
-  
-  subtest 'bad' => sub {
-    my($out, $value) = capture_merged {
-      $builder_bad->alien_check_installed_version,
-    };
-    note $out if $out ne '';
-    
-    is( $value, F(), "returns false if not found");
-    
-  };
 };
 
 done_testing;


### PR DESCRIPTION
If no pkg-config module is on the system, "pkg-config returned no
packages" skip is invoked in the
t/alien_base_modulebuild_pkgconfig.t, but because of missing SKIP
label, the test crashes:

    # perl -Ilib t/alien_base_modulebuild_pkgconfig.t
    [...]
    not ok 2 - version {
	ok 1 - skipped test # skip pkg-config returned no packages
	ok 2 - skipped test # skip pkg-config returned no packages
    }
    # Failed test 'version'
    # at t/alien_base_modulebuild_pkgconfig.t line 120.
    # Caught exception in subtest: Label not found for "last SKIP" at /usr/share/perl5/vendor_perl/Test2/Tools/Basic.pm line 74.
    1..2