### PR TITLE
run library tests prior to Perl tests

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 Revision history for Perl module Alien::Base.
 
+  - Run alien_install_commands before any Perl tests in t/
+
 0.045 2017-08-29 04:51:05 -0400
   - Fix broken skip in t/alien_base_modulebuild_pkgconfig.t
 

--- a/lib/Alien/Base/ModuleBuild.pm
+++ b/lib/Alien/Base/ModuleBuild.pm
@@ -475,10 +475,8 @@ sub ACTION_alien_code {
   return;
 }
 
-sub ACTION_test {
-  my $self = shift;
-  $self->SUPER::ACTION_test;
-
+sub ACTION_alien_test {
+  my $self = shift;  
   print "Testing library (if applicable) ... ";
   if ($self->config_data( 'install_type' ) eq 'share') {
     if (defined (my $wdir = $self->config_data( 'working_directory' ))) {
@@ -487,6 +485,12 @@ sub ACTION_test {
     }
   }
   print "Done\n";
+}
+
+sub ACTION_test {
+  my $self = shift;
+  $self->depends_on('alien_test');
+  $self->SUPER::ACTION_test;
 }
 
 sub ACTION_install {


### PR DESCRIPTION
Library tests have always come after Perl tests with ABMB, but it doesn't seem to make sense.  I don't think this change should break anything that isn't already broken.  On the other hand I don't know of anything this would fix that is broken under the current system.

As implemented in this PR, the Perl tests are not run at all if there is a fail in the alien_test_commands.  That seems sensible to me, but if anyone has objections we can entertain them.

As implemented in this PR, there is no option to change the order.  I think we have enough options, and I don't see the use case for adding an option for this.  We can entertain objections to this as well.

Proposing this on behalf of @a3f 

/cc: @jberger @mohawk2 @zmughal
