### PR TITLE
fix blib detection

### DIFF
--- a/lib/Alien/Base/ModuleBuild.pm
+++ b/lib/Alien/Base/ModuleBuild.pm
@@ -736,7 +736,7 @@ sub alien_detect_blib_scheme {
   (undef, my $dir, undef) = File::Spec->splitpath( __FILE__ );
   my @dirs = File::Spec->splitdir($dir);
 
-  shift @dirs while @dirs && $dirs[0];
+  shift @dirs while @dirs && $dirs[0] ne 'blib';
   return unless @dirs;
 
   if ( $dirs[1] && $dirs[1] eq 'lib' ) {

--- a/lib/Alien/Base/ModuleBuild/API.pod
+++ b/lib/Alien/Base/ModuleBuild/API.pod
@@ -319,6 +319,11 @@ The name of the folder which will both serve a stub share directory via L<Module
 
 =item alien_stage_install
 
+It might be tempting to use this option if you have a library or tool that hard codes paths from the install location inside the
+executable or library code.  However, using this option relies on blib detection which is not very reliable, and can leave your
+install in an broken state if the package install step fails.  If you really need this option, please consider instead migrating
+to L<Alien::Build>, which has a much more reliable way of staging installs correctly.
+
 [version 0.016]
 
 Alien packages are installed directly into the blib directory by the `./Build' command rather than to the final location during the `./Build install` step.
@@ -469,9 +474,15 @@ For sh, be sure to set the C<alien_msys> property so that it will work on Window
 
 =item %s
 
-The full path to the final installed location of the share directory (builder method C<alien_library_destination>). This is where the library should install itself; for autoconf style installs this will look like 
+The full path to the installed location of the the share directory (builder method C<alien_library_destination>).
+This is where the library should install itself; for autoconf style installs this will look like
 
  --prefix=%s
+
+This will be the local blib directory location if C<alien_stage_install> is true (which is the default as of 0.17.
+This will be the final install location if C<alien_stage_install> is false (which was the default prior to 0.17).
+Please see the documentation above on C<alien_stage_install> which includes some caveats before you consider changing
+this option.
 
 =item %v
 


### PR DESCRIPTION
This "fixes" blib detection after it was broken in a previous commit.  Note that blib detection is still inherently unreliable so ideally you don't use `alien_stage_install`.

Also update the documentation to reflect the new reality on how `%s` works with the default of `alien_stage_install` set to true (the default as of 0.17).  This was raised in #12 .