### PR TITLE
Declare dontpanic answer() before using it

### DIFF
--- a/t/inline.t
+++ b/t/inline.t
@@ -36,11 +36,11 @@ __C__
 
 #include <stdio.h>
 
+extern int answer();
+
 char *string_answer()
 {
   static char buffer[1024];
   sprintf(buffer, "the answer to life the universe and everything is %d", answer());
   return buffer;
 }
-
-extern int answer();

--- a/t/inline2.t
+++ b/t/inline2.t
@@ -33,11 +33,11 @@ __C__
 
 #include <stdio.h>
 
+extern int answer();
+
 char *string_answer()
 {
   static char buffer[1024];
   sprintf(buffer, "the answer to life the universe and everything is %d", answer());
   return buffer;
 }
-
-extern int answer();

--- a/t/inline_cpp.t
+++ b/t/inline_cpp.t
@@ -36,6 +36,10 @@ __CPP__
 
 #include <stdio.h>
 
+extern "C" {
+  int answer();
+}
+
 class Foo {
 public:
   char *string_answer()
@@ -45,5 +49,3 @@ public:
     return buffer;
   }
 };
-
-extern int answer();


### PR DESCRIPTION
After upgrading Acme-Alien-DontPanic from 2.1100 to 2.2600,
t/inline_cpp.t fails:

~~~~
g++ -D_REENTRANT -D_GNU_SOURCE -O2 -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fwrapv -fno-strict-aliasing -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -xc++ -c  -iquote"/home/test/fedora/perl-Alien-Base-ModuleBuild/Alien-Base-ModuleBuild-1.14/t" -I/usr  -D_REENTRANT -D_GNU_SOURCE -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fwrapv -fno-strict-aliasing -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -g   -DVERSION=\"0.00\" -DXS_VERSION=\"0.00\" -fPIC "-I/usr/lib64/perl5/CORE"   inline_cpp_t_a7ac.c
inline_cpp_t_a7ac.xs: In member function ‘char* Foo::string_answer()’:
inline_cpp_t_a7ac.xs:34:77: error: ‘answer’ was not declared in this scope
   34 |     sprintf(buffer, "the answer to life the universe and everything is %d", answer());
      |                                                                             ^~~~~~
~~~~

That's because the test declares answer() after unsing it. I have no idea why
the test passed before, but this patch makes GCC 10 happy. It was
also necessary to put the declaration into "C" namespace to prevent
from C++ symbol namespace mangling.

Now the test reports:

~~~~
1..0 # SKIP test requires that Acme::Alien::DontPanic was build with Alien::Base 0.006
~~~~

But that's probably a different bug.